### PR TITLE
Fix NetFlix issue when navigating from a none watch page

### DIFF
--- a/source/lib/functions.ts
+++ b/source/lib/functions.ts
@@ -2,7 +2,7 @@ import minimatch from 'minimatch'
 import { observe } from 'selector-observer'
 
 export const urlPatterns = {
-  netflix: ['*://netflix.com/watch/**', '*://*.netflix.com/watch/**'],
+  netflix: ['*://netflix.com/**', '*://*.netflix.com/**'],
   amazon: ['*://amazon.*/gp/video/**', '*://*.amazon.*/gp/video/**'],
 }
 

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -19,7 +19,7 @@
   "content_scripts": [
     {
       "js": ["content_scripts/netflix.js"],
-      "matches": ["*://netflix.com/watch/**", "*://*.netflix.com/watch/**"]
+      "matches": ["*://netflix.com/**", "*://*.netflix.com/**"]
     },
     {
       "js": ["content_scripts/amazon.js"],


### PR DESCRIPTION
Made NetFlix URL pattern more general, because else the content_script only gets executed on the initial page, not if you navigate from e.g. netflix.com to the watch page because the is no page reload involved