### PR TITLE
🚇 Deactivates dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
 version: 2
 updates:
-- package-ecosystem: npm
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: weekly
-    time: "04:00"
-  open-pull-requests-limit: 10
+    interval: "weekly"
+    day: friday
+    time: "18:00"
+    timezone: Europe/Amsterdam


### PR DESCRIPTION
No need to release each week, only update if there is a security risk.