### PR TITLE
📦🩹 Use valid min versions for v3 manifest

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -4,7 +4,7 @@
   "description": "Extension to auto click 'Skip Recap' and 'Skip Intro' on streaming pages, when they pop up",
   "homepage_url": "https://github.com/s-weigand/binge-stream",
   "manifest_version": 3,
-  "minimum_chrome_version": "74",
+  "minimum_chrome_version": "99",
   "icons": {
     "128": "icon.png"
   },

--- a/tools/firefox_manifest_append.ts
+++ b/tools/firefox_manifest_append.ts
@@ -13,7 +13,7 @@ const updateManifestFireFox = () => {
     browser_specific_settings: {
       gecko: {
         id: 'binge-stream@s-weigand',
-        strict_min_version: '67.0',
+        strict_min_version: '109.0',
       },
     },
   }


### PR DESCRIPTION
This fixes a publishing error in the chrome store due to a too low min version.
```
- Uploading distribution
{
  kind: 'chromewebstore#item',
  id: '***',
  uploadState: 'FAILURE',
Error: PKG_MANIFEST_PARSE_ERROR
The minimum Chrome version of 74 does not meet the minimum requirement to be published. To be published, a manifest V3 item must require at least Chrome version 88.
  itemError: [
    {
      error_code: 'PKG_MANIFEST_PARSE_ERROR',
      error_detail: 'The minimum Chrome version of 74 does not meet the minimum requirement to be published. To be published, a manifest V3 item must require at least Chrome version 88.'
    }
  ]
}
```
Even so, there was no error it also updates the min Firefox version to [a version that supports v3 manifests](https://blog.mozilla.org/addons/2022/11/17/manifest-v3-signing-available-november-21-on-firefox-nightly/).